### PR TITLE
Adds awsPrefix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A optional prefix to add to the uploaded destination of your built fastboot asse
   "key": "blog/dist-0.0.0+a3323e2.zip"
 }
 ```
+**Note** that a trailing slash is added to the value to separate it from the `archivePrefix` value.
 
 *Default:* `''`
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ The region your bucket is located in. (e.g. set this to `eu-west-1` if your buck
 
 *Default:* `undefined`
 
+### awsPrefix
+
+A optional prefix to add to the uploaded destination of your built fastboot assets. Useful if your app is hosted at a nested path on S3. For example if you set `awsPrefix` to `'blog'`, `fastboot-deploy-info.json` will look something like this:
+```json
+{
+  "bucket": "my-bucket",
+  "key": "blog/dist-0.0.0+a3323e2.zip"
+}
+```
+
+*Default:* `''`
+
 ### revisionKey
 
 The unique revision number for the version of the app. By default this option will use either the `revision` passed in from the command line or the `revisionData.revisionKey` property from the deployment context.

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function _list(opts) {
         return new Date(b.LastModified) - new Date(a.LastModified);
       })
       .map((d) => {
-        let match = d.Key.match(new RegExp(archivePrefix+'([^.]*)\\.zip'));
+        let match = d.Key.match(new RegExp(archivePrefix+'(.*)\\.zip'));
         if (!match) {
           return; // ignore files that are no zipped app builds
         }

--- a/index.js
+++ b/index.js
@@ -91,7 +91,8 @@ module.exports = {
           return context.fastbootDownloaderManifestContent;
         },
 
-        manifestKey: 'fastboot-deploy-info.json'
+        manifestKey: 'fastboot-deploy-info.json',
+        awsPrefix: ''
       },
 
       requiredConfig: ['bucket', 'region'],
@@ -100,16 +101,24 @@ module.exports = {
         let revisionKey   = this.readConfig('revisionKey');
         let bucket        = this.readConfig('bucket');
         let archivePrefix = this.readConfig('archivePrefix');
+        let awsPrefix     = this.readConfig('awsPrefix');
         // update manifest-file to point to passed revision
         let downloaderManifestContent = this.readConfig('downloaderManifestContent');
 
-        let manifest        = downloaderManifestContent(bucket, `${archivePrefix}${revisionKey}.zip`);
+        let buildKey        = `${archivePrefix}${revisionKey}.zip`;
+        if (awsPrefix) {
+          buildKey = `${awsPrefix}/${buildKey}`;
+        }
+
+        let manifest        = downloaderManifestContent(bucket, buildKey);
         let AWS             = require('aws-sdk');
         let RSVP            = require('rsvp');
         let accessKeyId     = this.readConfig('accessKeyId');
         let secretAccessKey = this.readConfig('secretAccessKey');
         let region          = this.readConfig('region');
         let manifestKey     = this.readConfig('manifestKey');
+
+        manifestKey = awsPrefix ? `${awsPrefix}/${manifestKey}` : manifestKey;
 
         let client = new AWS.S3({
           accessKeyId,
@@ -135,6 +144,7 @@ module.exports = {
         let secretAccessKey = this.readConfig('secretAccessKey');
         let bucket          = this.readConfig('bucket');
         let region          = this.readConfig('region');
+        let awsPrefix       = this.readConfig('awsPrefix');
 
         let client = new AWS.S3({
           accessKeyId,
@@ -146,10 +156,12 @@ module.exports = {
 
         let data = fs.readFileSync(context.fastbootArchivePath);
 
+        let key = awsPrefix ? `${awsPrefix}/${context.fastbootArchiveName}` : context.fastbootArchiveName;
+
         return putObject({
           Bucket: bucket,
           Body: data,
-          Key: context.fastbootArchiveName
+          Key: key
         });
       },
 
@@ -160,6 +172,10 @@ module.exports = {
         let bucket          = this.readConfig('bucket');
         let region          = this.readConfig('region');
         let manifestKey     = this.readConfig('manifestKey');
+        let awsPrefix       = this.readConfig('awsPrefix');
+
+        archivePrefix = awsPrefix ? `${awsPrefix}/${archivePrefix}` : archivePrefix;
+        manifestKey   = awsPrefix ? `${awsPrefix}/${manifestKey}` : manifestKey;
 
         let opts = {
           accessKeyId, secretAccessKey, archivePrefix, bucket, region, manifestKey
@@ -175,6 +191,10 @@ module.exports = {
         let bucket          = this.readConfig('bucket');
         let region          = this.readConfig('region');
         let manifestKey     = this.readConfig('manifestKey');
+        let awsPrefix       = this.readConfig('awsPrefix');
+
+        archivePrefix = awsPrefix ? `${awsPrefix}/${archivePrefix}` : archivePrefix;
+        manifestKey   = awsPrefix ? `${awsPrefix}/${manifestKey}` : manifestKey;
 
         let opts = {
           accessKeyId, secretAccessKey, archivePrefix, bucket, region, manifestKey

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -154,6 +154,31 @@ describe('fastboot-app-server-aws plugin', function() {
             assert.isTrue(false, 'upload failed');
           });
       });
+
+      it('uploads objects to a nested path if `awsPrefix` is set', function() {
+        let FILE_NAME = 'dist-78.zip';
+        let CONTENT   = 'testtest';
+        let PREFIX    = 'blog';
+        let KEY       = `${PREFIX}/${FILE_NAME}`;
+
+        fs.writeFileSync(FILE_NAME, CONTENT);
+
+        context.fastbootArchivePath = FILE_NAME;
+        context.fastbootArchiveName = FILE_NAME;
+
+        context.config['fastboot-app-server-aws'].awsPrefix = PREFIX;
+
+        return plugin.upload(context)
+          .then(() => {
+            return get({ Bucket: process.env.TEST_BUCKET, Key: KEY });
+          })
+          .then((data) => {
+            assert.equal(data.Body, CONTENT, 'file was uploaded correctly');
+          })
+          .catch(() => {
+            assert.isTrue(false, 'upload failed');
+          });
+      });
     });
 
     describe('#fetchRevisions', function() {
@@ -217,6 +242,35 @@ describe('fastboot-app-server-aws plugin', function() {
             let expected = {
               bucket: process.env.TEST_BUCKET,
               key: 'dist-56.zip'
+            };
+            let actual = JSON.parse(data.Body.toString());
+
+            assert.deepEqual(actual, expected, 'manifest file updated as expected');
+          })
+          .catch(() => {
+            assert.isTrue(false, "can't find manifest-file");
+          });
+      });
+
+      it('uploads the manifest with a key prefix if `awsPrefix` is set', function() {
+        let PREFIX = 'blog';
+
+        context.commandOptions = {
+          revision: '56'
+        };
+        context.config['fastboot-app-server-aws'].awsPrefix = PREFIX;
+
+        return plugin.activate(context)
+          .then(() => {
+            return get({
+              Bucket: process.env.TEST_BUCKET,
+              Key: `${PREFIX}/fastboot-deploy-info.json`
+            });
+          })
+          .then((data) => {
+            let expected = {
+              bucket: process.env.TEST_BUCKET,
+              key: `${PREFIX}/dist-56.zip`
             };
             let actual = JSON.parse(data.Body.toString());
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -33,18 +33,21 @@ function cleanBucket() {
     });
 }
 
-function setupTestData() {
+function setupTestData(ops = {}) {
   function addTestData() {
     let existingDists = ['dist-12.zip', 'dist-34.zip', 'dist-56.zip'];
     let promises = existingDists.map((n) => {
+      if (ops.awsPrefix) {
+        n = `${ops.awsPrefix}/${n}`;
+      }
       return put({ Bucket: process.env.TEST_BUCKET, Key: n, Body: 'Body: ' + n });
     });
     promises.push(put({
       Bucket: process.env.TEST_BUCKET,
-      Key: 'fastboot-deploy-info.json',
+      Key: (ops.awsPrefix ? `${ops.awsPrefix}/` : '') + 'fastboot-deploy-info.json',
       Body: JSON.stringify({
         bucket: process.env.TEST_BUCKET,
-        key: 'dist-34.zip'
+        key: (ops.awsPrefix ? `${ops.awsPrefix}/` : '') + 'dist-34.zip'
       })
     }));
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -194,6 +194,19 @@ describe('fastboot-app-server-aws plugin', function() {
           });
       });
 
+      it('respects `awsPrefix` when looking for revisions', function() {
+        let PREFIX = 'blog';
+        return setupTestData({ awsPrefix: PREFIX }).then(() => {
+          context.config['fastboot-app-server-aws'].awsPrefix = PREFIX;
+          return plugin.fetchRevisions(context)
+            .then((data) => {
+              let revisions = data.revisions.map((d) => d.revision);
+              assert.deepEqual(revisions, ['12', '34', '56']);
+              assert.isTrue(data.revisions[1].active, 'revision 34 marked current');
+            });
+        })
+      });
+
       it('does not fail when bucket is empty', function() {
         return cleanBucket()
           .then(() => {
@@ -214,6 +227,19 @@ describe('fastboot-app-server-aws plugin', function() {
             assert.deepEqual(revisions, ['12', '34', '56']);
             assert.isTrue(data.initialRevisions[1].active, 'revision 34 marked current');
           });
+      });
+
+      it('respects `awsPrefix` when fetching initial revisions', function() {
+        let PREFIX = 'blog';
+        return setupTestData({ awsPrefix: PREFIX }).then(() => {
+          context.config['fastboot-app-server-aws'].awsPrefix = PREFIX;
+          return plugin.fetchInitialRevisions(context)
+            .then((data) => {
+              let revisions = data.initialRevisions.map((d) => d.revision);
+              assert.deepEqual(revisions, ['12', '34', '56']);
+              assert.isTrue(data.initialRevisions[1].active, 'revision 34 marked current');
+            });
+        })
       });
 
       it('does not fail when bucket is empty', function() {


### PR DESCRIPTION
Most of the other S3 ember-cli-deploy plugins include a configuration to add prefix to files destined for an S3 bucket, e.g. to upload stuff to a nested path. This PR adds that config option, and a couple other items I noticed while digging around in the source.

- **log output**. I added some log output for verbose mode. I found this helpful while adding this feature
- **`_list` regex**. the regex in `_list` wasn't matching some revision keys due to including `[^.]*` in the pattern. `ember-cli-deploy-revision-data` uses version numbers and a commit hash by default in the form of `#.#.#+<hash>`, which means the literal `.` characters will fail the regex test. I changed the regex to match any character between `archivePrefix` and `.zip`. I think the fact that the pattern also includes `.zip` should ensure that it only matches zipped asset bundles.