### PR TITLE
profile options would not work for deploy:list

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function _list(opts) {
       return { revisions: revisionsResults, current: { Body: '{}'} };
     })
     .then((result) => {
-      if (result.revisions.length < 1) {
+      if (!result.revisions || result.revisions.length < 1) {
         return { revisions: [] };
       }
 
@@ -182,6 +182,7 @@ module.exports = {
         let archivePrefix   = this.readConfig('archivePrefix');
         let bucket          = this.readConfig('bucket');
         let region          = this.readConfig('region');
+        let profile         = this.readConfig('profile');
         let manifestKey     = this.readConfig('manifestKey');
         let awsPrefix       = this.readConfig('awsPrefix');
 
@@ -189,7 +190,7 @@ module.exports = {
         manifestKey   = awsPrefix ? `${awsPrefix}/${manifestKey}` : manifestKey;
 
         let opts = {
-          accessKeyId, secretAccessKey, archivePrefix, bucket, region, manifestKey
+          accessKeyId, secretAccessKey, archivePrefix, bucket, region, profile, manifestKey
         };
 
         return _list(opts)

--- a/index.js
+++ b/index.js
@@ -15,17 +15,18 @@ function _list(opts) {
   let profile         = opts.profile;
   let manifestKey     = opts.manifestKey
 
+  if (profile) {
+    console.log('using profile: ' + profile);
+    AWS.config.credentials = new AWS.SharedIniFileCredentials({
+      profile: profile
+    });
+  }
+
   let client = new AWS.S3({
     accessKeyId,
     secretAccessKey,
     region
   });
-
-  if (profile) {
-    AWS.config.credentials = new AWS.SharedIniFileCredentials({
-      profile: profile
-    });
-  }
 
   let listObjects = RSVP.denodeify(client.listObjects.bind(client));
   let getObject   = RSVP.denodeify(client.getObject.bind(client));
@@ -40,7 +41,8 @@ function _list(opts) {
     .then((current) => {
       return { revisions: revisionsResults, current };
     })
-    .catch(() => {
+    .catch((error) => {
+      console.error('failed to get revisions: ' + error);
       return { revisions: revisionsResults, current: { Body: '{}'} };
     })
     .then((result) => {
@@ -220,7 +222,7 @@ module.exports = {
           accessKeyId, secretAccessKey, archivePrefix, bucket, region, profile, manifestKey
         };
 
-        return _list(opts, this)
+        return _list(opts)
           .then((data) =>  {
             let revisions = data.revisions;
             revisions.forEach(r => {


### PR DESCRIPTION
the `profile` option is not picked up when running `deploy:list`, as this config is never read and it seems like the profile option needs to be set before calling the S3 constructor (as it is done in the other ember-deploy-s3 plugins)

I additionally tried to add some log statements, however I was unable to use `this.log`. Even when passing it as a params to `_list` would show an error:

```
TypeError: Cannot read property 'logInfoColor' of undefined
TypeError: Cannot read property 'logInfoColor' of undefined
    at log (node_modules/ember-cli-deploy-plugin/index.js:76:34)
```

So, I went with `console` statements as I am unaware of the finer nodejs and ember-deploy details and I currently don't have any time to look into it. Will be happy to modify if someone can point me in the right direction.